### PR TITLE
故意寫壞 Dockerfile 測試 GitHub Action 是否能偵測錯誤

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,3 @@ docker run -d -p 5000:5000 fifi1030/2025cloud:flaskapp
 * -d：讓容器在背景模式執行
 * -p：指定主機與容器的 Port 對應
 * Image Name：使用先前打包好的 Image
-
-

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM ng:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
 


### PR DESCRIPTION
此 PR 故意將 nginx.dockerfile 中的 FROM 指令打錯：將 nginx 打成 ng，目的是讓 GitHub Action 自動偵測 build 失敗。